### PR TITLE
Fix doubled scripts/ path in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Build workflow
 
-- Prepare datasets and validate references: run `Rscript -e "source('scripts/scripts/PrepareCourseData.R')"` (this syncs `CourseData/` from `DataSetLibrary/`, writes `course_data_files.csv`, and fails if a referenced dataset is missing).
+- Prepare datasets and validate references: run `Rscript -e "source('scripts/PrepareCourseData.R')"` (this syncs `CourseData/` from `DataSetLibrary/`, writes `course_data_files.csv`, and fails if a referenced dataset is missing).
 - Build the book: run `_build.sh` (which now runs the preparation step, then renders the gitbook).
 
 ### Build/release notes


### PR DESCRIPTION
Fixes a path typo in the README build instructions: the "Prepare datasets" step referenced `scripts/scripts/PrepareCourseData.R` (doubled `scripts/`), which would fail if copy-pasted. Corrected to `scripts/PrepareCourseData.R`.

This is the one genuinely useful, non-conflicting change identified while reviewing the unmerged `course-revisions` branch. The rest of that branch centres on adopting `renv`, which master deliberately moved away from, so it was left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rycx9ypSHoPe2C3FQUqbek)_