### PR TITLE
Introduce read.csv() and read_csv() early, then standardise on read.csv()

### DIFF
--- a/0_03-An_R_Refresher.Rmd
+++ b/0_03-An_R_Refresher.Rmd
@@ -244,21 +244,28 @@ str(mydata)
 
 ## Organising your work and importing data
 
-**What we’re about to do:** Import a CSV file using tidyverse tools.
+**What we’re about to do:** Import a CSV file, and meet the two functions you will see for doing this.
 
 Keep your data in a `CourseData` folder inside your project. We will use **relative paths** throughout this course. If you do not have `CourseData`, download it from the course site.
 
+There are two common ways to read a CSV file into R, and you will come across both:
+
+- **`read.csv()`** comes with base R. It returns a `data.frame` and, with `stringsAsFactors = TRUE`, turns text columns into **factors** — which is convenient for the statistics later in the course.
+- **`read_csv()`** comes from the `readr` package (part of the tidyverse). It is a little faster, prints a short summary of the column types it guessed, and returns a *tibble* (a modern data frame). It leaves text columns as character.
+
+Both work well and you will see both in other people's code. **To keep things consistent, this book uses `read.csv()` from here on.**
+
 ```{r 0-03-An-R-Refresher-20}
-carni <- readr::read_csv("CourseData/carnivora.csv")
+carni <- read.csv("CourseData/carnivora.csv", stringsAsFactors = TRUE)
 ```
 
-**What just happened:** `read_csv()` imported the data and guessed column types.
+**What just happened:** `read.csv()` imported the data as a `data.frame` and, thanks to `stringsAsFactors = TRUE`, stored the text columns as factors.
 
-**Try this:** Run `glimpse(carni)` and compare it to `summary(carni)`.
+**Try this:** Run `str(carni)` and compare it to `summary(carni)`.
 
 **Common mistake:** File not found. Check spelling and folder names.
 
-**Takeaway:** `read_csv()` is the tidyverse way to import CSV files.
+**Takeaway:** This book uses `read.csv()`; `read_csv()` is the tidyverse alternative you will also encounter.
 
 ---
 
@@ -286,7 +293,7 @@ summary(carni$FW)
 
 ```{r 0-03-An-R-Refresher-23}
 class(carni$Family)
-levels(as.factor(carni$Family))
+levels(carni$Family)
 ```
 
 ```{r 0-03-An-R-Refresher-24}
@@ -370,7 +377,7 @@ The file is `suburbanBirds.csv`. Columns: `Name`, `Year`, `HabitatIndex`, `nIndi
 
 - Use scripts for reproducible work.
 - Vectors and data frames are the core data types.
-- `read_csv()` is the tidyverse way to import CSV files.
+- `read.csv()` imports CSV files; `read_csv()` is the tidyverse alternative.
 - Check classes with `str()` and convert to `factor()` when needed.
 - Always inspect your data before analysing it.
 

--- a/0_05-PathsAndProjects.Rmd
+++ b/0_05-PathsAndProjects.Rmd
@@ -17,7 +17,7 @@ By the end of this chapter you should be able to:
 If your project is organised, this will work on any computer:
 
 ```{r 0-05-PathsAndProjects-1, eval = FALSE}
-readr::read_csv("CourseData/carnivora.csv")
+read.csv("CourseData/carnivora.csv")
 ```
 
 If your project is not organised, you end up with long absolute paths that break when shared.

--- a/2_01-visualisingData.Rmd
+++ b/2_01-visualisingData.Rmd
@@ -39,7 +39,7 @@ We have already made a plot: data + aesthetics + geom. That pattern will repeat 
 We will use the SDU clutch size data created at the end of the **Data wrangling** chapter. The file should be in `CourseData/SDUClutchSize.csv`.
 
 ```{r 2-01-visualisingData-2}
-clutch <- readr::read_csv("CourseData/SDUClutchSize.csv")
+clutch <- read.csv("CourseData/SDUClutchSize.csv")
 ```
 
 **Checkpoint:** You should see columns like `species`, `Year`, and `clutchSize`.
@@ -200,7 +200,7 @@ mean_clutch %>%
 **What we’re about to do:** We will plot how bird species richness changes with suburb age.
 
 ```{r 2-01-visualisingData-12}
-birds <- readr::read_csv("CourseData/suburbanBirds.csv") %>%
+birds <- read.csv("CourseData/suburbanBirds.csv") %>%
   mutate(Age = 1975 - Year)
 ```
 


### PR DESCRIPTION
Students will encounter both CSV-reading functions in the wild, so the R refresher now **introduces both** and explains the difference — then the book commits to **one** for consistency.

## What changed
- **`0_03` (R refresher)** — the "importing data" section now presents both functions before using one:
  - `read.csv()` (base R) → `data.frame`, and with `stringsAsFactors = TRUE` turns text into **factors**.
  - `read_csv()` (readr/tidyverse) → faster, prints guessed column types, returns a *tibble*, leaves text as character.
  - States plainly that the book uses `read.csv()` from here on, and switches the `carnivora` import accordingly (with `stringsAsFactors = TRUE`). Simplified `levels(as.factor(carni$Family))` → `levels(carni$Family)` since `Family` is now a factor.
- **`0_05`, `2_01`** — switched their `readr::read_csv()` calls back to `read.csv()`.

## Why `read.csv()` rather than `read_csv()`
- **Consistency / least churn:** 13 of 16 data-loading chapters already use `read.csv()` (all of Part 1 and Part 3); only the 3 recently-rescued chapters used `read_csv()`. This aligns those 3 with the rest rather than converting 13.
- **Factor safety:** the statistics chapters rely on factor behaviour (`relevel()`, `levels()` in ANOVA/ANCOVA). `read.csv(stringsAsFactors = TRUE)` provides that automatically; `read_csv()` would require adding explicit factor conversions across those chapters.

This resolves item 2 of the three consistency notes from PR #14. `library(tidyverse)` is left as-is (it coexists fine with `read.csv()`), so this is purely about the import function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rycx9ypSHoPe2C3FQUqbek)_