### PR TITLE
CI: build and deploy the book to GitHub Pages automatically

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -1,4 +1,4 @@
-name: Build Book
+name: Build and deploy book
 
 on:
   push:
@@ -8,6 +8,17 @@ on:
     # Every Monday at 06:00 UTC
     - cron: "0 6 * * 1"
   workflow_dispatch:
+
+# Permissions needed to deploy to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one Pages deployment at a time; don't cancel an in-progress one
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -39,3 +50,25 @@ jobs:
 
       - name: Build book (gitbook)
         run: ./_build.sh
+
+      # Only package the site for deployment on real pushes / scheduled /
+      # manual runs. Pull requests still build above (as a check) but are
+      # not deployed.
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    # Never deploy from a pull request
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Switches the workflow from **build-only** to **build-and-deploy**, using the modern GitHub Pages Actions flow. The site now rebuilds and redeploys automatically on every push to `master` (plus the weekly schedule and manual dispatch). Pull requests still build as a check but do **not** deploy.

## What changed
- Added `permissions` (`pages: write`, `id-token: write`) and a `pages` `concurrency` group.
- After `./_build.sh` renders the gitbook into `docs/`, the build job uploads it with `actions/upload-pages-artifact@v3`.
- A new `deploy` job publishes it with `actions/deploy-pages@v4` to the `github-pages` environment.
- Deploy/upload steps are gated with `if: github.event_name != 'pull_request'` so PRs validate the render without publishing.

## ⚠️ One-time setup required (only you can do this)
After merging, go to **Settings → Pages → Build and deployment → Source** and set it to **GitHub Actions** (currently it's "Deploy from a branch"). Until you flip this, the `deploy` job will fail with a message telling you to enable it.

## Recommended follow-up (separate PR, after this works)
Once the Actions deploy is confirmed live, we should **stop committing the rendered `docs/` folder** — it's rebuilt fresh in CI now, so keeping it in the repo just recreates the stale-HTML churn. That follow-up would `git rm -r --cached docs`, add `docs/` to `.gitignore`, and drop the manual local-render step from the README. I've left it out of this PR so nothing breaks before the Pages source is switched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rycx9ypSHoPe2C3FQUqbek)_