### PR TITLE
Freeze class data as a historical dataset (collected from students in previous years)

### DIFF
--- a/3_02-t-tests.Rmd
+++ b/3_02-t-tests.Rmd
@@ -352,7 +352,7 @@ The mathematics involved with calculating the t-statistic is very similar to the
 $$t = \frac{\bar{x_1}-\bar{x_2}} {\sqrt{\frac{s_1^2}{n_1} + \frac{s_2^2}{n_2}}}$$
 So far so good... let's push on and use R to do some statistics.
 
-In this example, we can revisit the class data and ask the question, *Is the reaction time of males different than that of females?* The null hypothesis for this question is that there is no difference in mean reaction times between the two groups. The alternative hypothesis is that there **is** a difference in the mean reaction time between the two groups.
+In this example, we can revisit the class data — a set of measurements (height, hand width, reaction time, and so on) collected from students in previous years of this course — and ask the question, *Is the reaction time of males different than that of females?* The null hypothesis for this question is that there is no difference in mean reaction times between the two groups. The alternative hypothesis is that there **is** a difference in the mean reaction time between the two groups.
 
 Import the data in the usual way, and subset it to the right year (in the example below I am using 2019 data).
 
@@ -414,7 +414,7 @@ summary(mod)
 
 ## Exercise: Sex differences in fine motor skills
 
-Some people have suggested that there might be sex differences in fine motor skills in humans. Use the data collected on the class to address this topic using t-tests. The relevant data set is called `classData.csv`, and the columns of interest are `Gender` and `Precision`.
+Some people have suggested that there might be sex differences in fine motor skills in humans. Use the data collected from students in previous years to address this topic using t-tests. The relevant data set is called `classData.csv`, and the columns of interest are `Gender` and `Precision`.
 
 Carry out a two-sample t-test. 
 

--- a/3_07-EvaluatingModels.Rmd
+++ b/3_07-EvaluatingModels.Rmd
@@ -8,7 +8,7 @@ There are some additional useful points to consider: proportion of variance expl
 
 During the 2+ way ANOVA (multiple regression) section you may have realised that there may be multiple ways to fit a model. For example, you may have a choice of parameters to include - should you include them or not? Which ones should you include? Would a log-transformed explanatory variable be better? 
 
-We will use the class data to look at these topics (download the latest version please). In this example, I am filtering the data to only 2019, but you can choose to use all the data (i.e. no filtering), or this year's data. 
+We will use the class data — collected from students in previous years — to look at these topics. In this example, I am filtering the data to only 2019, but you can choose to use all the data (i.e. no filtering), or any single year.
 
 ```{r 3-07-EvaluatingModels-1}
 classData <- read.csv("CourseData/classData.csv") %>%

--- a/6_1_00-AllSolutions.Rmd
+++ b/6_1_00-AllSolutions.Rmd
@@ -477,7 +477,7 @@ sum(diffs$diffs >= observedDiff) / 1000
 
 ## Sex differences in fine motor skills
 
-Some people have suggested that there might be sex differences in fine motor skills in humans. Use the data collected on the class to address this topic using t-tests. The relevant data set is called `classData.csv`, and the columns of interest are `Gender` and `Precision`.
+Some people have suggested that there might be sex differences in fine motor skills in humans. Use the data collected from students in previous years to address this topic using t-tests. The relevant data set is called `classData.csv`, and the columns of interest are `Gender` and `Precision`.
 
 Carry out a two-sample t-test. 
 


### PR DESCRIPTION
`classData.csv` (the student self-collected dataset — height, hand width, reaction time, gender, etc.) is still used as the core worked example in the linear regression, ANCOVA, and model-evaluation chapters. Collection stopped after 2022, but the text still implied it was ongoing. This reframes it as a fixed historical dataset without changing any analysis.

## Changes
- **`3_02` (t-tests)** — at the dataset's first use, added a one-line description of what it is and that it was **collected from students in previous years**; reworded the fine-motor-skills exercise ("data collected on the class" → "data collected from students in previous years").
- **`3_07` (evaluating models)** — removed the stale live-collection framing ("download the latest version please", "this year's data") and replaced it with historical framing plus "any single year".
- **`6_1_00` (solutions)** — matched the reworded exercise text.

No changes to code, data, or results — framing only. The dataset stays exactly where it is (it's too well-integrated in the regression/ANCOVA chapters to remove).

Note: the "latest version … on the website" line in `index.Rmd` refers to the *book*, not the data, so it was left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rycx9ypSHoPe2C3FQUqbek)_