### PR TITLE
Fix build: illustrative filenames tripping the missing-dataset check

### DIFF
--- a/0_04-Tips_and_Tricks.Rmd
+++ b/0_04-Tips_and_Tricks.Rmd
@@ -86,7 +86,7 @@ Plots appear in the **Plots** pane (usually bottom right). Use the back/forward 
 If you create a summary table, save it to CSV and open in Excel or Word.
 
 ```{r 0-04-Tips-and-Tricks-2, eval = FALSE}
-write.csv(my_table, file = "table.csv", row.names = FALSE)
+write.csv(my_table, file = "example.csv", row.names = FALSE)
 ```
 
 ---

--- a/0_05-PathsAndProjects.Rmd
+++ b/0_05-PathsAndProjects.Rmd
@@ -32,8 +32,8 @@ A file path is the address of a file on your computer. There are two types.
 
 These start from the root of your computer:
 
-- Windows: `C:/Users/YourName/Documents/Project/data.csv`
-- Mac: `/Users/YourName/Documents/Project/data.csv`
+- Windows: `C:/Users/YourName/Documents/Project/myData.csv`
+- Mac: `/Users/YourName/Documents/Project/myData.csv`
 
 **Why this is a problem:** Absolute paths are different on every computer, so shared code breaks.
 


### PR DESCRIPTION
`PrepareCourseData.R` scans the `.Rmd`s for `*.csv` references and halts the build if any referenced file is missing from `DataSetLibrary`. Two **illustrative filenames** in teaching prose (added by the content-overhaul rescue, #14) were being treated as real datasets:

- `0_04`: `write.csv(my_table, file = "table.csv", …)` → **`example.csv`**
- `0_05`: the absolute-path examples `…/Project/data.csv` → **`myData.csv`**

Both `example.csv` and `myData.csv` are already on the script's ignore list, so the missing-dataset check now passes (verified by replicating the script's extraction logic). No real datasets are involved, and the surrounding teaching text is unchanged in meaning.

This is what was producing:
```
Error: One or more datasets mentioned in the text are missing.
       Check datasets_missing.csv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rycx9ypSHoPe2C3FQUqbek)_