### PR TITLE
Add self-directed binomial GLM exercise (Sex and foot size)

### DIFF
--- a/3_08-GLM_1_Poisson.Rmd
+++ b/3_08-GLM_1_Poisson.Rmd
@@ -184,7 +184,7 @@ library(ggfortify)
 autoplot(mod1)
 ```
 
-These look a bit dodgy, but we'll stick with it for the moment.
+These look a bit dodgy, but we'll stick with it for the moment. (These `autoplot` diagnostics are hard to read here because the data are dominated by low counts and zeros. In the next chapter we will meet a simulation-based diagnostic tool, `DHARMa`, that makes awkward cases like this much clearer — it would be a good exercise to return to this model and re-examine it with DHARMa once you have learned about it.)
 
 Next ask for the Analysis of Variance table.
 

--- a/3_09-GLM-2_otherFamilies.Rmd
+++ b/3_09-GLM-2_otherFamilies.Rmd
@@ -442,3 +442,18 @@ ggplot(smoke, aes(
   geom_point() +
   geom_segment(aes(xend = parentSmoke, y = ymin, yend = ymax))
 ```
+
+## Exercise: Sex and foot size
+
+The data set `morphometry.csv` contains measurements taken from 154 people. For each person the data record their `Sex` (`Male` or `Female`) and three body measurements in millimetres: `Height`, `HandLength` and `FootLength`.
+
+This is the "predicting sex from morphology" scenario mentioned at the start of the chapter. Your task is to use a binomial GLM (logistic regression) to ask whether, and how well, you can predict a person's sex from their foot length. The structure is a good parallel to the NFL field goals example: the response is binary (here `Male` vs. `Female`) and there is a single continuous predictor. Unlike the examples above, this one is *not* worked through for you - use the NFL example as your template and figure out the steps yourself. Ask for help if you get stuck.
+
+1) Import the data. The response variable needs to be binary (0/1), so create a new column that is `1` when the person is male and `0` when they are female (`ifelse` is one way to do this). You will therefore be modelling the *probability of being male*.
+2) Plot the data (`geom_jitter` works well here - remember to adjust the `height` and `alpha` arguments as in the NFL example).
+3) Fit an appropriate binomial GLM predicting your 0/1 variable from `FootLength`.
+4) Check the model using `DHARMa` (`simulateResiduals`). Does the binomial family look appropriate?
+5) Get the analysis of deviance table (`anova` with `test = "Chi"`). Is foot length a significant predictor of sex?
+6) Obtain the `summary` table. Remember that these coefficients are on the logit scale.
+7) Use `predict` to add the fitted probability (and its 95% confidence interval) to your plot, back-transforming to the natural scale with the inverse link function.
+8) At what foot length is a person equally likely to be male or female (i.e. the probability of being male is 0.5)?

--- a/3_09-GLM-2_otherFamilies.Rmd
+++ b/3_09-GLM-2_otherFamilies.Rmd
@@ -128,6 +128,17 @@ The text on the Q-Q plot reports the results of three tests: the KS test, Disper
 
 As you can see, the two plots, and the in-built tests, indicate that the model structure is appropriate: The observed and expected points fall on the QQ diagonal line and the residuals versus predicted values plot looks like a random star-field without any patterns.
 
+This example illustrates a general principle. **DHARMa is a reliable, general-purpose diagnostic tool for GLMs.** Because it works by simulation, it produces trustworthy residuals whatever the error family (binomial, Poisson, and so on) and whatever the structure of the data. The traditional `autoplot` diagnostics, by contrast, become less and less reliable as the response data become more discrete. They are perfectly readable for ordinary linear models and remain acceptable for GLMs with *aggregated* or high-count responses, but they can be very misleading for *binary* (0/1) data like the NFL field goals. The reason is that, for binary data, the residual at any given fitted value can only take one of two possible values, so the Q-Q plot looks alarming even when the model is perfectly appropriate — which is exactly what we saw with `autoplot(nflMod)` earlier.
+
+```{block 3-09-GLM-2-diagnostic-rule, type="do-something"}
+**Which diagnostic when?**
+
+- **`autoplot` (deviance residuals):** fine for ordinary linear models, and acceptable for GLMs with *aggregated* or high-count data (e.g. grouped binomial `cbind` data, or Poisson counts that are not dominated by zeros).
+- **`DHARMa` (simulated residuals):** reliable for *all* GLMs. Essential for *binary* (0/1) data, where `autoplot` cannot be trusted.
+
+When in doubt, use DHARMa. If `autoplot` and DHARMa agree, you can be confident; if they disagree, believe DHARMa.
+```
+
 ### Continuing the analysis
 
 
@@ -270,11 +281,19 @@ Now lets fit the model.
 modA <- glm(y ~ Temperature, data = hawksbill, family = binomial)
 ```
 
-As ever, we should take a quick look at the model diagnostic plots - these look OK.
+As ever, we should take a quick look at the model diagnostic plots. Note the important difference from the NFL example: these turtle data are *aggregated* binomial data (each row summarises many individual turtles via `cbind`), rather than binary 0/1 data. As explained in the "Which diagnostic when?" box above, this is exactly the situation where the traditional `autoplot` deviance-residual plots *are* trustworthy — and here they look fine.
 
 ```{r 3-09-GLM-2-otherFamilies-20, echo=TRUE,fig.width=4,fig.height=4,fig.align='center', fig.pos = "ht",message=FALSE}
 library(ggfortify)
 autoplot(modA)
+```
+
+To confirm this, we can also check the model with DHARMa. Unlike the NFL binary case — where `autoplot` and DHARMa disagreed, and DHARMa was the one to trust — here the two approaches *agree* that the model is appropriate. That agreement is reassuring, and it is exactly what we expect for aggregated binomial data.
+
+```{r 3-09-GLM-2-DHARMa-turtle, echo=TRUE,fig.width=6,fig.height=4,fig.align='center',message=FALSE,warning=FALSE}
+library(DHARMa)
+sim_res <- simulateResiduals(fittedModel = modA)
+plot(sim_res)
 ```
 
 Now we can look at the anova table. This will tell us what we already know - there is a strong effect of temperature on sex ratio.

--- a/3_09-GLM-2_otherFamilies.Rmd
+++ b/3_09-GLM-2_otherFamilies.Rmd
@@ -443,17 +443,19 @@ ggplot(smoke, aes(
   geom_segment(aes(xend = parentSmoke, y = ymin, yend = ymax))
 ```
 
-## Exercise: Sex and foot size
+## Exercise: Forensic footprints
 
-The data set `morphometry.csv` contains measurements taken from 154 people. For each person the data record their `Sex` (`Male` or `Female`) and three body measurements in millimetres: `Height`, `HandLength` and `FootLength`.
+A crime has been committed. At the scene, investigators recover a single clear footprint, and from it a forensic technician estimates that the person who left it had a **foot length of 271 mm**. Was the culprit male or female?
 
-This is the "predicting sex from morphology" scenario mentioned at the start of the chapter. Your task is to use a binomial GLM (logistic regression) to ask whether, and how well, you can predict a person's sex from their foot length. The structure is a good parallel to the NFL field goals example: the response is binary (here `Male` vs. `Female`) and there is a single continuous predictor. Unlike the examples above, this one is *not* worked through for you - use the NFL example as your template and figure out the steps yourself. Ask for help if you get stuck.
+To answer this, you have access to a reference database, `morphometry.csv`, containing measurements from 155 people of known sex. For each person the data record their `Sex` (`Male` or `Female`) and three body measurements in millimetres: `Height`, `HandLength` and `FootLength`. Your job is to build a "forensic tool" - a binomial GLM (logistic regression) that predicts sex from foot length - evaluate how accurate it is, and then use it to make a prediction about the person who left the print.
 
-1) Import the data. The response variable needs to be binary (0/1), so create a new column that is `1` when the person is male and `0` when they are female (`ifelse` is one way to do this). You will therefore be modelling the *probability of being male*.
+This is the kind of binary (`Male` vs. `Female`) single-predictor problem you saw in the NFL field goals example, so use that worked example as your template. Unlike the examples above, this one is *not* worked through for you - figure out the steps yourself, and ask for help if you get stuck.
+
+1) Import the reference data. Your response variable needs to be binary (0/1), so create a new column that is `1` when the person is male and `0` when they are female (`ifelse` is one way to do this). You will therefore be modelling the *probability of being male*.
 2) Plot the data (`geom_jitter` works well here - remember to adjust the `height` and `alpha` arguments as in the NFL example).
 3) Fit an appropriate binomial GLM predicting your 0/1 variable from `FootLength`.
 4) Check the model using `DHARMa` (`simulateResiduals`). Does the binomial family look appropriate?
-5) Get the analysis of deviance table (`anova` with `test = "Chi"`). Is foot length a significant predictor of sex?
-6) Obtain the `summary` table. Remember that these coefficients are on the logit scale.
-7) Use `predict` to add the fitted probability (and its 95% confidence interval) to your plot, back-transforming to the natural scale with the inverse link function.
-8) At what foot length is a person equally likely to be male or female (i.e. the probability of being male is 0.5)?
+5) Get the analysis of deviance table (`anova` with `test = "Chi"`) and the `summary` table. Is foot length a significant predictor of sex? (Remember the coefficients are on the logit scale.)
+6) **How good is your forensic tool?** Use the model to predict the probability of being male for everyone in the reference database (`predict` with `type = "response"`), classify each person as male if that probability is greater than 0.5, and compare your classification with their true sex. What proportion of people does your tool classify correctly?
+7) **The crime scene.** Use `predict` to estimate the probability (and its 95% confidence interval) that a person with a foot length of 271 mm is male. What is your conclusion, and how confident are you? Would this be strong enough evidence to present in court?
+8) A second, fainter print at the scene suggests a foot length of about 249 mm. Predict the probability of being male for this print too. Why is it much harder to draw a conclusion here? (Think about the foot length at which the probability of being male is 0.5.)

--- a/6_1_00-AllSolutions.Rmd
+++ b/6_1_00-AllSolutions.Rmd
@@ -862,6 +862,87 @@ A + geom_point(
 ```
 
 
+## Sex and foot size
+
+1. Import the data and create a binary (0/1) response for the probability of being male.
+
+```{r 6-1-00-AllSolutions-82}
+morph <- read.csv("CourseData/morphometry.csv") %>%
+  mutate(male = ifelse(Sex == "Male", 1, 0))
+head(morph)
+```
+
+2. Plot the data.
+
+```{r 6-1-00-AllSolutions-83,fig.width=5,fig.height=3,fig.align='center',message=FALSE}
+(A <- ggplot(morph, aes(x = FootLength, y = male)) +
+  geom_jitter(height = 0.05, alpha = 0.5))
+```
+
+3. Fit an appropriate binomial GLM.
+
+```{r 6-1-00-AllSolutions-84}
+morphMod <- glm(male ~ FootLength, data = morph, family = binomial)
+```
+
+4. Check the model using `DHARMa`. The points fall on the QQ diagonal and the residual-versus-predicted plot is a random star-field with no patterns, so the binomial family is appropriate.
+
+```{r 6-1-00-AllSolutions-85,fig.width=6,fig.height=4,fig.align='center',message=FALSE,warning=FALSE}
+library(DHARMa)
+sim_res <- simulateResiduals(fittedModel = morphMod)
+plot(sim_res)
+```
+
+5. Analysis of deviance table. This shows that foot length is a highly significant predictor of sex.
+
+```{r 6-1-00-AllSolutions-86}
+anova(morphMod, test = "Chi")
+```
+
+6. The coefficient summary (on the logit scale). The positive slope for `FootLength` shows that the probability of being male increases with foot length.
+
+```{r 6-1-00-AllSolutions-87}
+summary(morphMod)
+```
+
+7. Add the fitted probability and 95% confidence interval to the plot, back-transforming to the natural scale with the inverse link function.
+
+```{r 6-1-00-AllSolutions-88,fig.width=5,fig.height=3,fig.align='center',message=FALSE}
+# Dataset to predict FROM
+newData <- data.frame(FootLength = seq(190, 285, 1))
+
+# Predictions on the scale of the linear predictor (logit)
+pv <- predict(morphMod, newdata = newData, se.fit = TRUE)
+newData <- newData %>%
+  mutate(fit_LP = pv$fit) %>%
+  mutate(lowerCI_LP = pv$fit - 1.96 * pv$se.fit) %>%
+  mutate(upperCI_LP = pv$fit + 1.96 * pv$se.fit)
+
+# Back-transform to the natural (probability) scale
+inverseFunction <- family(morphMod)$linkinv
+newData <- newData %>%
+  mutate(
+    fit = inverseFunction(fit_LP),
+    lowerCI = inverseFunction(lowerCI_LP),
+    upperCI = inverseFunction(upperCI_LP)
+  )
+
+A + geom_ribbon(
+  data = newData, aes(x = FootLength, ymin = lowerCI, ymax = upperCI),
+  fill = "grey75", alpha = 0.5, inherit.aes = FALSE
+) +
+  geom_line(data = newData, aes(x = FootLength, y = fit))
+```
+
+8. At what foot length is a person equally likely to be male or female? You can read this from the plot, or filter the predicted values for a probability close to 0.5. This happens at a foot length of around 245-250 mm (roughly the midpoint between the average female and male foot lengths).
+
+```{r 6-1-00-AllSolutions-89}
+newData %>%
+  filter(fit < 0.55) %>%
+  filter(fit > 0.45) %>%
+  select(FootLength, fit)
+```
+
 ## Snails on the move
 
 Simulate a t-test-based analysis in R to figure out what sample size would result in 80% power.

--- a/6_1_00-AllSolutions.Rmd
+++ b/6_1_00-AllSolutions.Rmd
@@ -862,9 +862,9 @@ A + geom_point(
 ```
 
 
-## Sex and foot size
+## Forensic footprints
 
-1. Import the data and create a binary (0/1) response for the probability of being male.
+1. Import the reference data and create a binary (0/1) response for the probability of being male.
 
 ```{r 6-1-00-AllSolutions-82}
 morph <- read.csv("CourseData/morphometry.csv") %>%
@@ -879,7 +879,7 @@ head(morph)
   geom_jitter(height = 0.05, alpha = 0.5))
 ```
 
-3. Fit an appropriate binomial GLM.
+3. Fit the binomial GLM - this is our "forensic tool".
 
 ```{r 6-1-00-AllSolutions-84}
 morphMod <- glm(male ~ FootLength, data = morph, family = binomial)
@@ -893,55 +893,62 @@ sim_res <- simulateResiduals(fittedModel = morphMod)
 plot(sim_res)
 ```
 
-5. Analysis of deviance table. This shows that foot length is a highly significant predictor of sex.
+5. The analysis of deviance table and coefficient summary. Foot length is a highly significant predictor of sex, and the positive slope shows that the probability of being male increases with foot length.
 
 ```{r 6-1-00-AllSolutions-86}
 anova(morphMod, test = "Chi")
-```
-
-6. The coefficient summary (on the logit scale). The positive slope for `FootLength` shows that the probability of being male increases with foot length.
-
-```{r 6-1-00-AllSolutions-87}
 summary(morphMod)
 ```
 
-7. Add the fitted probability and 95% confidence interval to the plot, back-transforming to the natural scale with the inverse link function.
+6. How good is the forensic tool? Predict the probability of being male for everyone in the reference data, classify as male when that probability exceeds 0.5, and compare with the truth. The confusion table and the overall accuracy show that the tool classifies about 90% of people correctly - good, but far from perfect because male and female foot lengths overlap.
 
-```{r 6-1-00-AllSolutions-88,fig.width=5,fig.height=3,fig.align='center',message=FALSE}
-# Dataset to predict FROM
-newData <- data.frame(FootLength = seq(190, 285, 1))
+```{r 6-1-00-AllSolutions-87}
+morph <- morph %>%
+  mutate(pMale = predict(morphMod, type = "response")) %>%
+  mutate(prediction = ifelse(pMale > 0.5, "Male", "Female"))
 
-# Predictions on the scale of the linear predictor (logit)
-pv <- predict(morphMod, newdata = newData, se.fit = TRUE)
-newData <- newData %>%
-  mutate(fit_LP = pv$fit) %>%
-  mutate(lowerCI_LP = pv$fit - 1.96 * pv$se.fit) %>%
-  mutate(upperCI_LP = pv$fit + 1.96 * pv$se.fit)
+# Confusion table: true sex versus predicted sex
+table(trueSex = morph$Sex, prediction = morph$prediction)
 
-# Back-transform to the natural (probability) scale
-inverseFunction <- family(morphMod)$linkinv
-newData <- newData %>%
-  mutate(
-    fit = inverseFunction(fit_LP),
-    lowerCI = inverseFunction(lowerCI_LP),
-    upperCI = inverseFunction(upperCI_LP)
-  )
-
-A + geom_ribbon(
-  data = newData, aes(x = FootLength, ymin = lowerCI, ymax = upperCI),
-  fill = "grey75", alpha = 0.5, inherit.aes = FALSE
-) +
-  geom_line(data = newData, aes(x = FootLength, y = fit))
+# Overall proportion correctly classified
+mean(morph$prediction == morph$Sex)
 ```
 
-8. At what foot length is a person equally likely to be male or female? You can read this from the plot, or filter the predicted values for a probability close to 0.5. This happens at a foot length of around 245-250 mm (roughly the midpoint between the average female and male foot lengths).
+7. The crime scene. Predict the probability that the person with a 271 mm foot was male, with a 95% confidence interval, back-transforming to the probability scale with the inverse link function.
+
+```{r 6-1-00-AllSolutions-88}
+crimeScene <- data.frame(FootLength = 271)
+
+pv <- predict(morphMod, newdata = crimeScene, se.fit = TRUE)
+inverseFunction <- family(morphMod)$linkinv
+
+crimeScene <- crimeScene %>%
+  mutate(
+    probMale = inverseFunction(pv$fit),
+    lowerCI = inverseFunction(pv$fit - 1.96 * pv$se.fit),
+    upperCI = inverseFunction(pv$fit + 1.96 * pv$se.fit)
+  )
+crimeScene
+```
+
+The probability of being male is very high (well above 0.9), so the evidence points strongly to a male culprit. Note, however, that "very likely" is not "certain": a small number of women in the reference data have feet this large, so on its own this would be suggestive rather than conclusive evidence.
+
+8. The second print (249 mm). Repeat the prediction for a foot length of 249 mm.
 
 ```{r 6-1-00-AllSolutions-89}
-newData %>%
-  filter(fit < 0.55) %>%
-  filter(fit > 0.45) %>%
-  select(FootLength, fit)
+crimeScene2 <- data.frame(FootLength = 249)
+pv2 <- predict(morphMod, newdata = crimeScene2, se.fit = TRUE)
+
+crimeScene2 <- crimeScene2 %>%
+  mutate(
+    probMale = inverseFunction(pv2$fit),
+    lowerCI = inverseFunction(pv2$fit - 1.96 * pv2$se.fit),
+    upperCI = inverseFunction(pv2$fit + 1.96 * pv2$se.fit)
+  )
+crimeScene2
 ```
+
+Here the probability of being male is close to 0.5, so the tool is essentially guessing. A foot length of 249 mm sits almost exactly at the "tipping point" where males and females are equally likely (around 245-250 mm, roughly the midpoint between the average female and male foot lengths), so this print tells us very little about the culprit's sex. This is an important lesson: a prediction is only as useful as the certainty attached to it.
 
 ## Snails on the move
 


### PR DESCRIPTION
Add a lightly-specified 'Exercise: Sex and foot size' at the end of the
binomial GLM chapter, using the previously-unused morphometry.csv dataset
for a binary logistic regression predicting sex from foot length. This
mirrors the self-directed exercise pattern used in other chapters (e.g.
the Maze runner exercise in the Poisson GLM chapter). Add the matching
worked solution to the exercise solutions chapter.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W8F1La8wF34mA5D3xkX4PJ