### PR TITLE
Seed remaining stochastic chunks for reproducible rebuilds

### DIFF
--- a/3_01-randomisationTests.Rmd
+++ b/3_01-randomisationTests.Rmd
@@ -244,6 +244,7 @@ Another useful way to plot this data is to use an **interaction plot**. In these
 ```
 
 ```{r 3-01-randomisationTests-19, echo=FALSE}
+set.seed(42)
 an2 <- an %>%
   group_by(Subject) %>%
   mutate(time = sample(time))

--- a/3_03-ANOVA.Rmd
+++ b/3_03-ANOVA.Rmd
@@ -420,6 +420,7 @@ As you can see, the method is a bit laborious and time consuming but it is conce
 
 ```{r 3-03-ANOVA-27, echo=FALSE}
 # the following is some code to make a plot with shuffled data as an illustration of how the ANOVA works
+set.seed(42)
 espressoShuffled <- espresso %>%
   mutate(foamIndx = sample(foamIndx))
 

--- a/6_1_00-AllSolutions.Rmd
+++ b/6_1_00-AllSolutions.Rmd
@@ -874,7 +874,8 @@ head(morph)
 
 2. Plot the data.
 
-```{r 6-1-00-AllSolutions-83,fig.width=5,fig.height=3,fig.align='center',message=FALSE}
+```{r 6-1-00-AllSolutions-83, echo=-1,fig.width=5,fig.height=3,fig.align='center',message=FALSE}
+set.seed(42)
 (A <- ggplot(morph, aes(x = FootLength, y = male)) +
   geom_jitter(height = 0.05, alpha = 0.5))
 ```

--- a/6_1_00-AllSolutions.Rmd
+++ b/6_1_00-AllSolutions.Rmd
@@ -391,6 +391,7 @@ diff(as.vector(tapply(hercules$width, hercules$sex, mean)))
 8. Use `sample` to randomise the sex column of the data, and recalculate the difference between the mean.
 
 ```{r 6-1-00-AllSolutions-36}
+set.seed(42)
 # with dplyr
 hercules %>%
   mutate(sex = sample(sex)) %>%
@@ -406,6 +407,7 @@ diff(as.vector(tapply(hercules$width, sample(hercules$sex), mean)))
 9. Use `replicate` to repeat this 10 times (to ensure that you code works).
 
 ```{r 6-1-00-AllSolutions-37}
+set.seed(43)
 # with dplyr
 replicate(
   10,
@@ -430,6 +432,7 @@ replicate(
 10. When your code is working, use `replicate` again, but this time with 1000 replicates and pass the results into a data frame.
 
 ```{r 6-1-00-AllSolutions-38}
+set.seed(44)
 # with dplyr
 diffs <- data.frame(
   diffs =
@@ -957,6 +960,7 @@ Simulate a t-test-based analysis in R to figure out what sample size would resul
 
 
 ```{r 6-1-00-AllSolutions-80}
+set.seed(42)
 sampleSize <- 40 # vary this until power > 0.8
 result <- replicate(
   1000,
@@ -975,6 +979,7 @@ You should find that you need a sample size of about 40 per group.
 What difference in strength could you reliably detect (with power >80%) with these sample sizes?
 
 ```{r 6-1-00-AllSolutions-81}
+set.seed(42)
 diff <- 185 # Vary this to give a difference to 2nd group t-test
 result <- replicate(
   1000,


### PR DESCRIPTION
Ensures book rebuilds do not unnecessarily change plots or reported values, from a reproducibility audit of every stochastic operation in the built book (root `.Rmd` plus `scripts/`).

The book already seeds most stochastic chunks, `scripts/SimulateData.R` seeds each data block, and DHARMa's `simulateResiduals()` is reproducible by default (internal `seed = 123`). This closes the remaining gaps — chunks that drew random numbers without a local seed and so depended on the global RNG stream (fragile to reordering and `cache = TRUE`):
- **`3_01`** — seed the `sample()`-shuffled randomisation illustration plot.
- **`3_03`** — seed the `sample()`-shuffled ANOVA illustration plot.
- **`6_1_00` (solutions)** — seed the forensic-footprints `geom_jitter` plot; the Hercules-beetle randomisation (seeding the 1000-replicate chunk also stabilises the null-distribution histogram and the reported p-value); and the Snails and Mouse-lemur power solutions (stable reported power value).

After this, every stochastic chunk in the built book has its own local seed. `historicExams/` is intentionally left alone (uses `set.seed(Sys.time())`, excluded from the build).

Note: the "Probability, odds, and uncertainty" section is **not** part of this PR — it went in separately (see #26). An earlier edit to this description incorrectly listed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8F1La8wF34mA5D3xkX4PJ