### PR TITLE
Normalise figure sizes for PDF and screen

### DIFF
--- a/3_03-ANOVA.Rmd
+++ b/3_03-ANOVA.Rmd
@@ -210,7 +210,7 @@ summary(foam_mod2)
 Now the coefficients in the model summary look different, but the model is actually the same. Compare the two graphs in Figure \@ref(fig:3-03-ANOVA-14) - can you see the differences/similarities?
 
 
-```{r 3-03-ANOVA-14, echo=FALSE,fig.width=8,fig.height=3,fig.align='center', fig.cap="Comparison illustrating the difference between ANOVA models using (A) BM and (B) HIP as references in the espresso foam data set.",cache=TRUE}
+```{r 3-03-ANOVA-14, echo=FALSE,fig.width=6.5,fig.height=3,fig.align='center', fig.cap="Comparison illustrating the difference between ANOVA models using (A) BM and (B) HIP as references in the espresso foam data set.",cache=TRUE}
 set.seed(31)
 
 temp <- data.frame(
@@ -306,7 +306,7 @@ The difference between those values is called the *Treatment Sum of Squares (SST
 If that doesn't make sense yet, picture the case where the treatment-specific means are all very similar, and are therefore very close to the overall mean. Now the difference between the *Total Sum of Squares* and the *Error Sum of Squares* will be small. Sketch out a couple of examples with pen on paper if that helps. You should now see that you can investigate differences among means by looking at variation.
 
 
-```{r 3-03-ANOVA-18, echo=FALSE,fig.width=8,fig.height=3,fig.align='center', message = FALSE, fig.cap="The relative size of the squared residual errors from the overall mean (SSTotal) (A) and from the treatment-specific means (SSError) (B) tell us about the importance of the treatment variable. The difference between the two values is the \"treatment sum of squares\".", fig.pos = "ht"}
+```{r 3-03-ANOVA-18, echo=FALSE,fig.width=6.5,fig.height=3,fig.align='center', message = FALSE, fig.cap="The relative size of the squared residual errors from the overall mean (SSTotal) (A) and from the treatment-specific means (SSError) (B) tell us about the importance of the treatment variable. The difference between the two values is the \"treatment sum of squares\".", fig.pos = "ht"}
 overallMean <- espresso %>%
   summarise(overallMean = mean(foamIndx)) %>%
   pull()

--- a/3_04-linearRegression.Rmd
+++ b/3_04-linearRegression.Rmd
@@ -212,7 +212,7 @@ $$F = \frac{mESS}{mRSS}$$
 
 If the *explained variance* (mESS) is large compared to the *residual error variance* (mRSS), then F will be large. The size of F tells us how likely or unlikely it is that the null hypothesis is true. When F is large, the probability that the slope is significantly different from 0 is high. To obtain the actual probabilities, the F-value must be compared to a theoretical distribution which depends on the two degrees of freedom (explained and residual d.f.). Once upon a time you would have looked this up in a printed table, but now R makes this very straightforward.
 
-```{r 3-04-linearRegression-4, echo=FALSE,fig.width=8,fig.height=3,fig.align='center',fig.cap="(A) the total variation around the overall mean Height value (B) the residual error of the model.",fig.pos = "ht"}
+```{r 3-04-linearRegression-4, echo=FALSE,fig.width=6.5,fig.height=3,fig.align='center',fig.cap="(A) the total variation around the overall mean Height value (B) the residual error of the model.",fig.pos = "ht"}
 morph <- read.csv("CourseData/morphometry.csv") %>%
   mutate(Height = Height / 10, HandLength = HandLength / 10)
 

--- a/3_05-ANCOVA.Rmd
+++ b/3_05-ANCOVA.Rmd
@@ -6,7 +6,7 @@ In a simple case, you might be interested in a model with a continuous response 
 
 Some of these possible outcomes are illustrated in Figure \@ref(fig:3-05-ANCOVA-1). We might see that neither of the two explanatory variables has a significant effect. We might see that one does but not the other. We might see an interaction effect (where the effect of one variable, e.g. hand length, depends on the other, e.g. sex). We might also see an interaction effect but no main effect.
 
-```{r 3-05-ANCOVA-1, echo=FALSE,fig.width=10,fig.height=4,fig.align='center',fig.cap="Some potential results of the experiment. There may be a significant effect (or not) of both of the main effects (diet and genotype) and there may be a significant interaction effect (or not).", fig.pos = "ht",message=FALSE}
+```{r 3-05-ANCOVA-1, echo=FALSE,fig.width=8,fig.height=3.5,fig.align='center',fig.cap="Some potential results of the experiment. There may be a significant effect (or not) of both of the main effects (diet and genotype) and there may be a significant interaction effect (or not).", fig.pos = "ht",message=FALSE}
 fakeData <- expand.grid(contVar = c(1, 5), categVar = c("A", "B"))
 
 # No effect of contVar nor categVar

--- a/3_06-n-way_ANOVA.Rmd
+++ b/3_06-n-way_ANOVA.Rmd
@@ -7,7 +7,7 @@ The two-way ANOVA is an extension of one-way ANOVA that allows you to investigat
 For example, one might run an experiment investigating the effect of two types of diet (*lowProtein* and *highProtein*) and genotype (*gt1* and *gt2*) on adult size of a pest species. It is worth thinking about what potential outcomes there are for this experiment. There may be no effect of diet, and no effect of genotype. There may be an effect of one of these variables but not the other. The effect of the diet might be the same for the different genotypes, or it might be different. Some of these possible outcomes are illustrated in Figure \@ref(fig:3-06-n-way-ANOVA-1). The titles indicate with Y (yes) or N (no) whether the figure shows a significant diet, genotype (gt) or interaction (int) effect. The dotted lines joining the estimates for the two genotypes are a kind of **interaction plot**: where they are parallel, there is no interaction.
 
 
-```{r 3-06-n-way-ANOVA-1, echo=FALSE,fig.width=10,fig.height=4,fig.align='center',fig.cap="Some potential results of the experiment. There may be a significant effect (or not) of both of the main effects (diet and genotype) and there may be a significant interaction effect (or not).", fig.pos = "ht",message=FALSE}
+```{r 3-06-n-way-ANOVA-1, echo=FALSE,fig.width=8,fig.height=3.5,fig.align='center',fig.cap="Some potential results of the experiment. There may be a significant effect (or not) of both of the main effects (diet and genotype) and there may be a significant interaction effect (or not).", fig.pos = "ht",message=FALSE}
 fakeData <- expand.grid(diet = c("lowP", "highP"), genotype = c("gt1", "gt2"))
 
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -14,7 +14,8 @@ description: "Course book for BB852 at the Biology Department, University of Sou
 
 ```{r index-1, setOptions, include=FALSE}
 knitr::opts_chunk$set(
-  warning = FALSE, message = FALSE
+  warning = FALSE, message = FALSE,
+  fig.align = "center", fig.width = 6, fig.height = 4
 )
 set.seed(183975)
 ```


### PR DESCRIPTION
From an audit of every plotting chunk against the two outputs (gitbook ≈ 8 in column; A4 `pdf_book` ≈ 5–5.5 in text width, with no global `out.width`, so pandoc caps images at the text width and scales wider figures down).

## Changes
**Global defaults** (`index.Rmd` `opts_chunk`): add `fig.align="center"`, `fig.width=6`, `fig.height=4`. About 65 plotting chunks (mostly in the visualisation tutorial and the solutions) previously set no size and fell back to knitr's 7×5 default; they now render at a consistent, sensible size in both outputs. Chunks that specify their own dimensions are unaffected.

**Trim the widest outliers** (they were scaled down most in the PDF, shrinking their labels):
- `3_05` / `3_06` — the 6-panel "potential results" illustration: `10×4 → 8×3.5`.
- `3_03` (×2) and `3_04` — two-panel A/B comparison figures: `8×3 → 6.5×3`.

## Note
I can't render the book here (no R runtime; egress blocks the deployed site), so these are size choices reasoned from the page geometry, not eyeballed. Worth a glance at the built PDF — particularly the two 6-panel figures (`3_05-1` / `3_06-1`), which are inherently tight for an A4 column; if their panel titles still read small, a two-row re-layout would help more than a width change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8F1La8wF34mA5D3xkX4PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8F1La8wF34mA5D3xkX4PJ)_